### PR TITLE
Fix Mozilla margin bug

### DIFF
--- a/visualisations/summary/index.html
+++ b/visualisations/summary/index.html
@@ -35,7 +35,6 @@
 
     .container.section-3col-box-wrapper {
         margin-top: -300px;
-        top: -300px;
     }
 
     @-moz-document url-prefix() {


### PR DESCRIPTION
The top margin was being misplaced in shorter screens with squared aspect ratio. Removing extra attribute provides the fix.