### PR TITLE
Update Union Budget Explorer 2020 Budget Profile Receipts data

### DIFF
--- a/visualisations/union-budget-explorer(2020)/3-balance-column/data.csv
+++ b/visualisations/union-budget-explorer(2020)/3-balance-column/data.csv
@@ -3,5 +3,5 @@ no.,Type,Category,Sub-category,Particular,Actuals 2018-2019,Budget Estimates 201
 1,Receipts,Revenue Receipts,...,Total Revenue Receipts,1435233,1725738,1729682,1977693
 16,Receipts,Capital Receipts,,Total Capital Receipts,763518,772529,848450,1074306
 28,Expenditure,Total Budgetary Expenditure,...,Total Budgetary Expenditure,2315113,2786349,2698552,3042230
-29,Expenditure,Total Budgetary Expenditure,Central Expenditure,Total Central Expenditure,2419793,2849690,2706987,3037187
+29,Expenditure,Total Budgetary Expenditure,Central Expenditure,Total Central Expenditure,2419793,2189219.29,2706987,2328984.02
 33,Expenditure,Total Budgetary Expenditure,Transfers,Transfers,477965,597130,3616670,713246

--- a/visualisations/union-budget-explorer(2020)/Expenditure-bubble/index.html
+++ b/visualisations/union-budget-explorer(2020)/Expenditure-bubble/index.html
@@ -264,12 +264,12 @@
                 </div>
                 <div class="row">
                     <div class="left-panel-text">
-                        This section presents the ministry-wise allocations presented in the Union Budget 2019-20. In this year's budget there are 100 Demands in total.
+                        This section presents the ministry-wise allocations presented in the Union Budget 2020-21. In this year's budget there are 100 Demands in total.
                     </div>
                 </div>
                 <div class="row">
                     <div id="obi-colorKey">
-                        <p class="help-text-1">Colour represents increase and cut in allocation in comparison with 2018-2019 </p>
+                        <p class="help-text-1">Colour represents increase and cut in allocation in comparison with 2019-2020(BE) </p>
                         <ul class="obi-colorSwatches">
                             <li class="change-decrease3"></li>
                             <li class="change-decrease2"></li>

--- a/visualisations/union-budget-explorer(2020)/budget-profile/data.csv
+++ b/visualisations/union-budget-explorer(2020)/budget-profile/data.csv
@@ -1,5 +1,5 @@
 no.,Type,Category,Sub-category,Particular,color_group,label_display,label_pos,Notes,Actuals 2016-2017,Budget Estimates 2017-2018,Revised Estimates 2017-2018,Budget Estimates 2018-2019,Actuals 2017-2018,Budget Estimates 2018-2019,Revised Estimates 2018-2019,Budget Estimates 2019-2020,Actuals 2018-2019,Budget Estimates 2019-2020,Revised Estimates 2019-2020,Budget Estimates 2020-2021
-0,Receipts,...,...,Total Receipts,1,1,bottom,...,1984088.84,2133890.58,2257129.06,2399147.3,2137882,2399147,2416034,2732903,2316434,2735290,2698551,3095233
+0,Receipts,...,...,Total Receipts,1,1,bottom,...,1984088.84,2133890.58,2257129.06,2399147.3,2137882,2399147,2416034,2732903,2315113,2786349,2698551,3042230
 1,Receipts,Revenue Receipts,...,Total Revenue Receipts,1,1,"bottom,right",...,1374202.98,1515771.08,1505427.5,1725737.79,1435233,1725738,1729682,1977693,1552916,1962761,1850100,2020926
 2,Receipts,Revenue Receipts,Centre's Net Tax Revenue,Centre's Net Tax Revenue,1,1,"bottom,right",...,1101372.09,1227014.01,1269453.86,1480649.04,1242488,1480649,1484406,1705046,1317211,1649582,1504587,1635909
 3,Receipts,Revenue Receipts,Centre's Net Tax Revenue,Corporation Tax,1,1,,...,484923.86,538744.73,563744.73,621000,571202,621000,671000,760000,663572,766000,610500,681000

--- a/visualisations/union-budget-explorer(2020)/budget-profile/links.csv
+++ b/visualisations/union-budget-explorer(2020)/budget-profile/links.csv
@@ -1,7 +1,7 @@
 source,source_name,target,destination_name,value,type
 0,Total Receipts,1,Total Revenue Receipts,5,reverse
 0,Total Receipts,16,Total Capital Receipts,5,reverse
-0,Total Receipts,27,Draw-Down of Cash Balance,1,reverse
+0,Total Receipts,27,Draw-Down of Cash Balance,1,
 1,Total Revenue Receipts,2,Centre's Net Tax Revenue,3,reverse
 1,Total Revenue Receipts,11,Total Non-Tax Revenue,3,reverse
 2,Centre's Net Tax Revenue,3,Corporation Tax,1,reverse


### PR DESCRIPTION
Remove Draw-Down of Cash Balance figures from Total Receipts to make figures comparable across time-series 